### PR TITLE
Support of golang types Time, Uint and Uint64 added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,16 @@ services:
   - docker
 
 go:
-  - 1.4
-  - 1.5.1
+  - 1.6
 
 env:
   - ORIENT_VERS=2.1.5
 
 matrix:
   include:
-    - go: 1.5.1
+    - go: 1.6
       env: ORIENT_VERS=2.1.2
-    - go: 1.5.1
+    - go: 1.6
       env: ORIENT_VERS=2.0
 
 install:
@@ -26,7 +25,6 @@ install:
   - export TRAVIS_BUILD_DIR=$GOPATH/src/gopkg.in/istreamdata/orientgo.v2
   - cd $GOPATH/src/gopkg.in/istreamdata/orientgo.v2
   - docker pull dennwc/orientdb:${ORIENT_VERS}
-  - go get golang.org/x/tools/cmd/vet
 #  - go get golang.org/x/tools/cmd/cover
 #  - go get github.com/golang/lint/golint
   - go get -t -v ./...

--- a/type.go
+++ b/type.go
@@ -214,6 +214,8 @@ func OTypeForValue(val interface{}) (ftype OType) {
 		ftype = LINKLIST
 	case *RidBag:
 		ftype = LINKBAG
+	case time.Time:
+		ftype = DATETIME
 	// TODO: more types need to be added
 	default:
 		if isDecimal(val) {
@@ -249,6 +251,14 @@ func OTypeForValue(val interface{}) (ftype OType) {
 			} else {
 				ftype = LONG
 			}
+		case reflect.Uint:
+			if uintSize == 4 {
+				ftype = INTEGER
+			} else {
+				ftype = LONG
+			}
+		case reflect.Uint64:
+			ftype = LONG
 		case reflect.String:
 			ftype = STRING
 		case reflect.Struct:

--- a/type.go
+++ b/type.go
@@ -12,32 +12,30 @@ type OType byte
 
 // in alignment with: http://orientdb.com/docs/last/Types.html
 const (
-	BOOLEAN OType = iota
-	INTEGER
-	SHORT
-	LONG
-	FLOAT
-	DOUBLE
-	DATETIME
-	STRING
-	BINARY // means []byte
-	EMBEDDED
-	EMBEDDEDLIST
-	EMBEDDEDSET
-	EMBEDDEDMAP
-	LINK
-	LINKLIST
-	LINKSET
-	LINKMAP
-	BYTE
-	TRANSIENT
-	DATE
-	CUSTOM
-	DECIMAL
-	LINKBAG
-	ANY
-)
-const (
+	BOOLEAN      OType = 0
+	INTEGER      OType = 1
+	SHORT        OType = 2
+	LONG         OType = 3
+	FLOAT        OType = 4
+	DOUBLE       OType = 5
+	DATETIME     OType = 6
+	STRING       OType = 7
+	BINARY       OType = 8 // means []byte
+	EMBEDDED     OType = 9
+	EMBEDDEDLIST OType = 10
+	EMBEDDEDSET  OType = 11
+	EMBEDDEDMAP  OType = 12
+	LINK         OType = 13
+	LINKLIST     OType = 14
+	LINKSET      OType = 15
+	LINKMAP      OType = 16
+	BYTE         OType = 17
+	TRANSIENT    OType = 18
+	DATE         OType = 19
+	CUSTOM       OType = 20
+	DECIMAL      OType = 21
+	LINKBAG      OType = 22
+	ANY          OType = 23
 	UNKNOWN OType = 255 // driver addition
 )
 

--- a/type.go
+++ b/type.go
@@ -12,35 +12,40 @@ type OType byte
 
 // in alignment with: http://orientdb.com/docs/last/Types.html
 const (
-	BOOLEAN      OType = 0
-	INTEGER      OType = 1
-	SHORT        OType = 2
-	LONG         OType = 3
-	FLOAT        OType = 4
-	DOUBLE       OType = 5
-	DATETIME     OType = 6
-	STRING       OType = 7
-	BINARY       OType = 8 // means []byte
-	EMBEDDED     OType = 9
-	EMBEDDEDLIST OType = 10
-	EMBEDDEDSET  OType = 11
-	EMBEDDEDMAP  OType = 12
-	LINK         OType = 13
-	LINKLIST     OType = 14
-	LINKSET      OType = 15
-	LINKMAP      OType = 16
-	BYTE         OType = 17
-	TRANSIENT    OType = 18
-	DATE         OType = 19
-	CUSTOM       OType = 20
-	DECIMAL      OType = 21
-	LINKBAG      OType = 22
-	ANY          OType = 23
-	UNKNOWN      OType = 255 // driver addition
+	BOOLEAN OType = iota
+	INTEGER
+	SHORT
+	LONG
+	FLOAT
+	DOUBLE
+	DATETIME
+	STRING
+	BINARY // means []byte
+	EMBEDDED
+	EMBEDDEDLIST
+	EMBEDDEDSET
+	EMBEDDEDMAP
+	LINK
+	LINKLIST
+	LINKSET
+	LINKMAP
+	BYTE
+	TRANSIENT
+	DATE
+	CUSTOM
+	DECIMAL
+	LINKBAG
+	ANY
+)
+const (
+	UNKNOWN OType = 255 // driver addition
 )
 
 // detect the int size (4 or 8 bytes)
-const intSize = unsafe.Sizeof(int(0))
+const (
+	intSize  = unsafe.Sizeof(int(0))
+	uintSize = unsafe.Sizeof(uint(1))
+)
 
 func (t OType) String() string { // do not change - it may be used as field type for SQL queries
 	switch t {


### PR DESCRIPTION
Minor changes: iota used instead of defining const values by hand
